### PR TITLE
Fixing className import in renderElement.ts

### DIFF
--- a/src/component/renderElement.ts
+++ b/src/component/renderElement.ts
@@ -5,7 +5,7 @@ import {
   BulmaClassName,
   TrunxProps,
   trunxPropsToClassnamesObject
-} from './classnames'
+} from './classNames'
 import {
   extractModifiersProps,
   modifierPropsToClassnamesObject


### PR DESCRIPTION
Hey @fibo 

Thanks for doing all this work on trunx! I have been looking for a bulma react library that is still being support and this is great!

Getting the following error trying to install on a linux machine

```
Error: Could not resolve './classnames' from node_modules/trunx/component/renderElement.js
```

I'm guessing you are working on a Mac and that's why this hasn't been an issue for you (Mac by default uses a case insensitive partition - I had issues with this type of thing at my previous job all the time with failing import statements once pushed on to a linux box).
