### PR TITLE
Support React 17.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "homepage": "https://trunx.dev",
   "peerDependencies": {
-    "react": "16.x"
+    "react": "16.x||17.x"
   },
   "devDependencies": {
     "@types/classnames": "^2.2.11",


### PR DESCRIPTION
Since "React 17 release is unusual because it doesn’t add any new developer-facing features",
https://reactjs.org/blog/2020/10/20/react-v17.html