### PR TITLE
add custom classNames implementation

### DIFF
--- a/.ackrc
+++ b/.ackrc
@@ -1,6 +1,0 @@
-# Ack is awesome: https://beyondgrep.com/
-#
-# To ignore the options below use `ack --noenv`.
-###
---smart-case
---ignore-dir=docs

--- a/package-lock.json
+++ b/package-lock.json
@@ -3639,7 +3639,7 @@
       }
     },
     "packages/trunx": {
-      "version": "0.42.1",
+      "version": "0.42.2",
       "license": "MIT",
       "dependencies": {
         "bulma": "0.9.4",

--- a/packages/trunx/.npmignore
+++ b/packages/trunx/.npmignore
@@ -1,2 +1,3 @@
 media/
 src/
+test/

--- a/packages/trunx/package.json
+++ b/packages/trunx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trunx",
-  "version": "0.42.1",
+  "version": "0.42.2",
   "description": "Super Saiyan React components, son of awesome Bulma",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/trunx/src/Button.tsx
+++ b/packages/trunx/src/Button.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 
 import { ErrorBoundaryProps } from './ErrorBoundary'
-import { bulmaClassName, classNames } from './classNames'
+import { bulmaClassName, classNames } from './classNames.js'
 import {
   HelpersProps,
   MainColorsProps,
@@ -68,7 +68,7 @@ export class Button extends React.Component<ButtonProps> {
 
     if (this.state.hasError) return fallbackUI
 
-    const className = classNames<string>(
+    const className = classNames(
       bulmaClassName.button,
       classNameProp,
       {

--- a/packages/trunx/src/Button.tsx
+++ b/packages/trunx/src/Button.tsx
@@ -1,8 +1,7 @@
-import classnames from 'classnames'
 import * as React from 'react'
 
 import { ErrorBoundaryProps } from './ErrorBoundary'
-import { bulmaClassName } from './classNames'
+import { bulmaClassName, classNames } from './classNames'
 import {
   HelpersProps,
   MainColorsProps,
@@ -69,7 +68,7 @@ export class Button extends React.Component<ButtonProps> {
 
     if (this.state.hasError) return fallbackUI
 
-    const className = classnames(
+    const className = classNames<string>(
       bulmaClassName.button,
       classNameProp,
       {
@@ -104,9 +103,7 @@ export class Button extends React.Component<ButtonProps> {
           </button>
         )
       } else {
-        return (
-          <input className={className} type={type} value={value} {...props} />
-        )
+        return <input className={className} type={type} value={value} {...props} />
       }
     }
 

--- a/packages/trunx/src/Navbar.tsx
+++ b/packages/trunx/src/Navbar.tsx
@@ -1,8 +1,7 @@
-import classnames from 'classnames'
 import * as React from 'react'
 
 import { ErrorBoundaryProps } from './ErrorBoundary'
-import { bulmaClassName, trunxPropsToClassnamesObject } from './classNames'
+import { bulmaClassName, classNames, trunxPropsToClassnamesObject } from './classNames'
 import {
   HelpersProps,
   MainColorsProps,
@@ -108,17 +107,16 @@ class NavbarBurger extends React.Component<NavbarBurgerProps> {
   state = { hasError: false }
 
   render(): React.ReactNode {
-    const [
-      modifiersProps,
-      { className, fallbackUI, isActive, ...props },
-    ] = extractModifiersProps(this.props)
+    const [modifiersProps, { className, fallbackUI, isActive, ...props }] = extractModifiersProps(
+      this.props
+    )
 
     if (this.state.hasError) return fallbackUI
 
     return (
       <a
         aria-expanded={isActive ? 'true' : 'false'}
-        className={classnames(
+        className={classNames<string>(
           bulmaClassName.navbarBurger,
           className,
           modifierPropsToClassnamesObject(modifiersProps),
@@ -190,14 +188,7 @@ class NavbarItem extends React.Component<NavbarItemProps> {
   state = { hasError: false }
 
   render(): React.ReactNode {
-    const {
-      fallbackUI,
-      hasDropdown,
-      hasDropdownUp,
-      isActive,
-      isHoverable,
-      ...props
-    } = this.props
+    const { fallbackUI, hasDropdown, hasDropdownUp, isActive, isHoverable, ...props } = this.props
 
     if (this.state.hasError) return fallbackUI
 
@@ -302,14 +293,7 @@ export class Navbar extends React.Component<NavbarProps> {
   }
 
   render(): React.ReactNode {
-    const {
-      fallbackUI,
-      isFixedBottom,
-      isFixedTop,
-      isTransparent,
-      isUnselectable,
-      ...props
-    } = this.props
+    const { fallbackUI, isFixedBottom, isFixedTop, isTransparent, isUnselectable, ...props } = this.props
 
     if (this.state.hasError) return fallbackUI
 

--- a/packages/trunx/src/Navbar.tsx
+++ b/packages/trunx/src/Navbar.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 
 import { ErrorBoundaryProps } from './ErrorBoundary'
-import { bulmaClassName, classNames, trunxPropsToClassnamesObject } from './classNames'
+import { bulmaClassName, classNames, trunxPropsToClassnamesObject } from './classNames.js'
 import {
   HelpersProps,
   MainColorsProps,

--- a/packages/trunx/src/classNames.ts
+++ b/packages/trunx/src/classNames.ts
@@ -7,22 +7,39 @@ export type ClassNamesArg<ClassName extends string> =
  * Utility for conditionally joining CSS classes together.
  *
  * @example
- * type C = 'foo' | 'bar' // my CSS classes
- * classNames<C>('foo', 'bar') // 'foo bar'
- * classNames<C>('foo', ['bar']) // 'foo bar'
- * classNames<C>({ foo: true }, { bar: false }) // 'foo'
+ * classNames('foo', 'bar') // 'foo bar'
+ * classNames('foo', ['bar']) // 'foo bar'
+ * classNames({ foo: true }, { bar: false }) // 'foo'
+ *
+ * It accepts a generic "class names" type.
+ *
+ * @example
+ * type T = 'foo' | 'bar' // my CSS classes
+ * classNames<T>('foo', 'quz') // ERROR: not assignable to type ClassNamesArg<T>[]
  */
 export const classNames = <T extends string>(...args: ClassNamesArg<T>[]): string =>
   args
     .map((arg) => {
-      if (typeof arg === 'string') return arg
-      if (Array.isArray(arg) && arg.length) return classNames<string>(...arg)
-      if (arg && typeof arg === 'object')
-        return classNames<string>(
+      if (Array.isArray(arg)) {
+        // Recursively call classNames or return empty string if arg is an empty array.
+        return arg.length ? classNames(...arg) : ''
+      } else if (
+        // In this `else` branch, arg is not an Array.
+        // Make sure arg is not null,
+        arg &&
+        // and arg is a proper Object.
+        typeof arg === 'object'
+      ) {
+        return classNames(
+          // Map object to an array of its keys,
           Object.entries(arg)
-            .filter(([_key, val]) => val)
+            // with a truthy value.
+            .filter(([_, value]) => value)
             .map(([key]) => key)
         )
+      }
+      // Return arg if it is a string, or fallback to empty string.
+      return typeof arg === 'string' ? arg : ''
     })
     .join(' ')
 

--- a/packages/trunx/src/classNames.ts
+++ b/packages/trunx/src/classNames.ts
@@ -1,3 +1,22 @@
+export type ClassNamesArg<ClassName extends string> =
+  | ClassName
+  | { [key in ClassName]: unknown }
+  | ClassNamesArg<ClassName>[]
+
+export const classNames = <T extends string>(...args: ClassNamesArg<T>[]): string =>
+  args
+    .map((arg) => {
+      if (typeof arg === 'string') return arg
+      if (Array.isArray(arg) && arg.length) return classNames<string>(...arg)
+      if (arg && typeof arg === 'object')
+        return classNames<string>(
+          Object.entries(arg)
+            .filter(([_key, val]) => val)
+            .map(([key]) => key)
+        )
+    })
+    .join(' ')
+
 export interface TrunxProps {
   [props: string]: boolean | undefined
 }
@@ -5,11 +24,7 @@ export interface TrunxProps {
 function kebabCaseToCamelCase(value: string): string {
   return value
     .split('-')
-    .map((part, index) =>
-      index > 0
-        ? part.charAt(0).toUpperCase() + part.slice(1).toLowerCase()
-        : part
-    )
+    .map((part, index) => (index > 0 ? part.charAt(0).toUpperCase() + part.slice(1).toLowerCase() : part))
     .join('')
 }
 
@@ -24,9 +39,7 @@ function kebabCaseToCamelCase(value: string): string {
  * https://gist.github.com/nblackburn/875e6ff75bc8ce171c758bf75f304707
  */
 export function camelCaseToKebabCase(inputString: string): string {
-  return inputString
-    .replace(/([a-z0-9]|(?=[A-Z]))([A-Z0-9])/g, '$1-$2')
-    .toLowerCase()
+  return inputString.replace(/([a-z0-9]|(?=[A-Z]))([A-Z0-9])/g, '$1-$2').toLowerCase()
 }
 
 /**
@@ -35,9 +48,7 @@ export function camelCaseToKebabCase(inputString: string): string {
  *
  * ['a', 'b', 'foo-bar'] ---> { a: 'a', b: 'b', fooBar: 'foo-bar' }
  */
-function listToKeyValues<T extends string>(
-  list: readonly T[]
-): { [key: string]: T } {
+function listToKeyValues<T extends string>(list: readonly T[]): { [key: string]: T } {
   return list.reduce(
     (obj: { [key: string]: T }, key: T) => ({
       ...obj,
@@ -53,11 +64,7 @@ export function trunxPropsToClassnamesObject(props?: TrunxProps) {
   return Object.keys(props).reduce((obj, key) => {
     if (typeof props[key] === 'undefined') return obj
 
-    if (
-      key.substring(0, 3) === 'are' ||
-      key.substring(0, 3) === 'has' ||
-      key.substring(0, 2) === 'is'
-    ) {
+    if (key.substring(0, 3) === 'are' || key.substring(0, 3) === 'has' || key.substring(0, 2) === 'is') {
       const className = camelCaseToKebabCase(key)
 
       obj[className] = props[key]

--- a/packages/trunx/src/classNames.ts
+++ b/packages/trunx/src/classNames.ts
@@ -3,6 +3,15 @@ export type ClassNamesArg<ClassName extends string> =
   | { [key in ClassName]: unknown }
   | ClassNamesArg<ClassName>[]
 
+/**
+ * Utility for conditionally joining CSS classes together.
+ *
+ * @example
+ * type C = 'foo' | 'bar' // my CSS classes
+ * classNames<C>('foo', 'bar') // 'foo bar'
+ * classNames<C>('foo', ['bar']) // 'foo bar'
+ * classNames<C>({ foo: true }, { bar: false }) // 'foo'
+ */
 export const classNames = <T extends string>(...args: ClassNamesArg<T>[]): string =>
   args
     .map((arg) => {

--- a/webapps/trunx-docs/pages/index.tsx
+++ b/webapps/trunx-docs/pages/index.tsx
@@ -1,6 +1,6 @@
 import Head from 'next/head'
 import { Container, Section, Title } from 'trunx'
-import { Nav } from '../components'
+import { Nav } from '@/components'
 
 export default function Home() {
   return (


### PR DESCRIPTION
The idea is to replace classnames package with a typed implementation that accepts the classes list.

Then we are going to use a `bulma` classNames helper that has the bulma classes but the user will be able to use also custom classes.