### PR TITLE
add /bulma and /classNames exports

### DIFF
--- a/packages/trunx/package.json
+++ b/packages/trunx/package.json
@@ -9,6 +9,14 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./bulma": {
+      "import": "./dist/bulma.js",
+      "types": "./dist/bulma.d.ts"
+    },
+    "./classNames": {
+      "import": "./dist/classNames.js",
+      "types": "./dist/classNames.d.ts"
     }
   },
   "engines": {


### PR DESCRIPTION
Let use `bulma` and `classNames` helpers also outside of React.

```js
import {bulma} from 'trunx/bulma'
```

or

```js
import {classNames} from 'trunx/classNames'
```