### PR TITLE
Fixing htmlFor property not passing to base label component

### DIFF
--- a/packages/trunx/src/components/Label.tsx
+++ b/packages/trunx/src/components/Label.tsx
@@ -9,8 +9,9 @@ export const Label: FC<PropsWithChildren<LabelProps>> = ({
   children,
   className,
   size,
+  ...props,
 }) => {
   const _class = classNames("label", sizeClassName(size), className)
 
-  return <label className={_class}>{children}</label>
+  return <label className={_class} {...props}>{children}</label>
 }


### PR DESCRIPTION
I started using `trunx` because of the awesome name but I noticed that when I was using the `Label` component that the `htmlFor` property was not causing `Label`s to be associated with `Input`s. This PR should fix that by passing the props to the base component.