### PR TITLE
NavbarBurger support is-active class

### DIFF
--- a/packages/trunx/src/components/Navbar.tsx
+++ b/packages/trunx/src/components/Navbar.tsx
@@ -78,7 +78,7 @@ export const NavbarBurger: FC<NavbarBurgerProps> = ({
   setIsActive,
   ...props
 }) => {
-  const _class = classNames("navbar-burger", className)
+  const _class = classNames("navbar-burger", { "is-active": isActive }, className)
 
   const onClick: PointerEventHandler<HTMLDivElement> = (event) => {
     event.stopPropagation()


### PR DESCRIPTION
According to the `navbar-burger` documentation the `is-active` class should toggle the `navbar-burger` between a burger and a cross. https://bulma.io/documentation/components/navbar/#navbar-burger